### PR TITLE
travis: pip install coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - env
   - ls -al $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/lib/python$TRAVIS_PYTHON_VERSION/site-packages
   - "pip install -r requirements/test.txt"
-  - "pip install -q python-coveralls"
+  - "pip install coveralls"
   - ls -al $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/lib/python$TRAVIS_PYTHON_VERSION/site-packages
   - "python setup.py install"
   
@@ -26,3 +26,4 @@ script: nosetests
 
 after_success:
   - coveralls
+


### PR DESCRIPTION
Replacing python-coveralls with coveralls to get the 'coveralls' command working again. Not sure why this has changed.
