### PR TITLE
travis and coverage fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
   directories:
     - $HOME/.cache/pip
     - $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/lib/python$TRAVIS_PYTHON_VERSION/site-packages
+    - $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/bin
 
 addons:
   apt:
@@ -16,6 +17,7 @@ addons:
 install:
   - env
   - ls -al $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/lib/python$TRAVIS_PYTHON_VERSION/site-packages
+  - ls -al $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/bin
   - "pip install -r requirements/test.txt"
   - "pip install coveralls"
   - ls -al $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/lib/python$TRAVIS_PYTHON_VERSION/site-packages

--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,8 @@ APACHE License. (see `LICENSE`_)
     :target: https://travis-ci.org/dls-controls/malcolm
     :alt: Build Status
 
-.. |coverage| image:: https://coveralls.io/repos/dls-controls/malcolm/badge.svg?branch=develop
-    :target: https://coveralls.io/r/dls-controls/malcolm?branch=develop
+.. |coverage| image:: https://coveralls.io/repos/dls-controls/malcolm/badge.svg?branch=master&service=github
+    :target: https://coveralls.io/github/dls-controls/malcolm?branch=master
     :alt: Test coverage
 
 .. |pypi-version| image:: https://img.shields.io/pypi/v/malcolm.svg


### PR DESCRIPTION
I discovered that the "coveralls" command did not work (it was missing) after caching the site-packages. The problem was that as site-packages are cached, pip refuse to install coverage again - but the bin/coverage exe has not been cached... Well, it is now.

Also fixed a URL issue with the coverage badge in the README.
